### PR TITLE
asset.rbのprecompile設定を有効化。

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( admin.js admin.css )


### PR DESCRIPTION
AWSデプロイにあたって、nginxもunicornも動くが、cssが反映されない。
この対処によって反映されるか確認する。